### PR TITLE
Created implementation of the IAB Consent String 1.1 Spec

### DIFF
--- a/bit_string.go
+++ b/bit_string.go
@@ -1,0 +1,54 @@
+package iabconsent
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type BitString struct {
+	value string
+}
+
+func (b BitString) ParseInt64(offset, size int) (int64, error) {
+	return strconv.ParseInt(b.value[offset:(offset+size)], 2, 64)
+}
+
+func (b BitString) ParseInt(offset, size int) (int, error) {
+	var s, err = strconv.ParseInt(b.value[offset:(offset+size)], 2, 0)
+	return int(s), err
+}
+
+func (b BitString) ParseBitList(offset, size int) map[int]interface{} {
+	var purposes = make(map[int]interface{})
+	for i, v := range b.value[offset:(offset + size)] {
+		if v == '1' {
+			purposes[i+1] = true
+		}
+	}
+	return purposes
+}
+
+func (b BitString) ParseBit(offset int) bool {
+	return b.value[offset] == '1'
+}
+
+func (b BitString) ParseString(offset, size int) (string, error) {
+	var numChars = size / 6
+	var retString = ""
+
+	if size%6 != 0 {
+		return "", fmt.Errorf("bit string length must be multiple of 6")
+	}
+	for i := 0; i < numChars; i++ {
+		str, _ := b.ParseInt64(offset+6*i, 6)
+		retString = retString + string(str+65)
+	}
+	return retString, nil
+}
+
+func ParseBytes(b []byte) (bs BitString) {
+	for _, s := range b {
+		bs.value = bs.value + fmt.Sprintf("%08b", s)
+	}
+	return
+}

--- a/bit_string.go
+++ b/bit_string.go
@@ -5,20 +5,45 @@ import (
 	"strconv"
 )
 
-type BitString struct {
+// bitString is a simple struct which has only one field, value.
+// The value is expected to be a string containing only ones and zeros
+// which represent a Vendor Consent String as defined by the IAB spec
+// found here: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#vendor-consent-string-format-.
+// The type is defined to enable common operations needed to parse
+// the string which are defined below.
+type bitString struct {
 	value string
 }
 
-func (b BitString) ParseInt64(offset, size int) (int64, error) {
+// parseBytes takes in a []byte |b| and returns a bitString |bs|
+// who's value is the concatenation of the 8 bit binary representation
+// of each element of |b|.
+func parseBytes(b []byte) (bs bitString) {
+	for _, s := range b {
+		bs.value = bs.value + fmt.Sprintf("%08b", s)
+	}
+	return
+}
+
+// parseInt64 takes a bit offset and size and converts the binary
+// number produced from that substring slice into an int64.
+func (b bitString) parseInt64(offset, size int) (int64, error) {
 	return strconv.ParseInt(b.value[offset:(offset+size)], 2, 64)
 }
 
-func (b BitString) ParseInt(offset, size int) (int, error) {
-	var s, err = strconv.ParseInt(b.value[offset:(offset+size)], 2, 0)
+// parseInt takes a bit offset and size and converts the binary
+// number produced from that substring slice into an int.
+func (b bitString) parseInt(offset, size int) (int, error) {
+	var s, err = b.parseInt64(offset, size)
 	return int(s), err
 }
 
-func (b BitString) ParseBitList(offset, size int) map[int]interface{} {
+// parseBitList takes a bit offset and size which specify a range
+// of bits in the bitString's value which represent an ordered list
+// of bits representing purposes as defined in the IAB spec.
+// More on the purposes here: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md#purposes-features.
+// The resulting map's keys represent the purposes allowed for this user.
+func (b bitString) parseBitList(offset, size int) map[int]interface{} {
 	var purposes = make(map[int]interface{})
 	for i, v := range b.value[offset:(offset + size)] {
 		if v == '1' {
@@ -28,11 +53,17 @@ func (b BitString) ParseBitList(offset, size int) map[int]interface{} {
 	return purposes
 }
 
-func (b BitString) ParseBit(offset int) bool {
+// parseBit returns a bool representing the bit at the
+// passed offset.
+func (b bitString) parseBit(offset int) bool {
 	return b.value[offset] == '1'
 }
 
-func (b BitString) ParseString(offset, size int) (string, error) {
+// parseString take a bit offset and size which should represent
+// size / 6 characters to be parsed. Each six bits is parsed into
+// a letter and returned in a final string. parseString will error
+// if size is not divisible by 6.
+func (b bitString) parseString(offset, size int) (string, error) {
 	var numChars = size / 6
 	var retString = ""
 
@@ -40,15 +71,8 @@ func (b BitString) ParseString(offset, size int) (string, error) {
 		return "", fmt.Errorf("bit string length must be multiple of 6")
 	}
 	for i := 0; i < numChars; i++ {
-		str, _ := b.ParseInt64(offset+6*i, 6)
+		str, _ := b.parseInt64(offset+6*i, 6)
 		retString = retString + string(str+65)
 	}
 	return retString, nil
-}
-
-func ParseBytes(b []byte) (bs BitString) {
-	for _, s := range b {
-		bs.value = bs.value + fmt.Sprintf("%08b", s)
-	}
-	return
 }

--- a/bit_string_test.go
+++ b/bit_string_test.go
@@ -1,0 +1,75 @@
+package iabconsent
+
+import (
+	gc "github.com/go-check/check"
+)
+
+type BitStringSuite struct{}
+
+func (p *BitStringSuite) TestParseBytes(c *gc.C) {
+	b := []byte{1, 2, 3, 4}
+	s := "00000001000000100000001100000100"
+	bs := parseBytes(b)
+
+	c.Check(bs.value, gc.Equals, s)
+}
+
+func (p *BitStringSuite) TestParseInt(c *gc.C) {
+	i, err := dummyBitString().parseInt(4, 100)
+	c.Check(err.Error(), gc.Equals, "index out of range")
+
+	i, err = dummyBitString().parseInt(4, 8)
+	c.Check(err, gc.IsNil)
+	c.Check(i, gc.Equals, 78)
+}
+
+func (p *BitStringSuite) TestParseInt64(c *gc.C) {
+	i, err := dummyBitString().parseInt64(4, 100)
+	c.Check(err.Error(), gc.Equals, "index out of range")
+
+	i, err = dummyBitString().parseInt64(4, 8)
+	c.Check(err, gc.IsNil)
+	c.Check(i, gc.Equals, int64(78))
+}
+
+func (p *BitStringSuite) TestParseBitList(c *gc.C) {
+	i, err := dummyBitString().parseBitList(4, 100)
+	c.Check(err.Error(), gc.Equals, "index out of range")
+
+	i, err = dummyBitString().parseBitList(4, 8)
+	c.Check(err, gc.IsNil)
+	c.Check(i, gc.DeepEquals, map[int]interface{}{
+		2: true,
+		5: true,
+		6: true,
+		7: true,
+	})
+}
+
+func (p *BitStringSuite) TestParseBit(c *gc.C) {
+	i, err := dummyBitString().parseBit(100)
+	c.Check(err.Error(), gc.Equals, "index out of range")
+
+	i, err = dummyBitString().parseBit(4)
+	c.Check(err, gc.IsNil)
+	c.Check(i, gc.Equals, false)
+}
+
+func (p *BitStringSuite) TestParseString(c *gc.C) {
+	i, err := dummyBitString().parseString(4, 11)
+	c.Check(err.Error(), gc.Equals, "bit string length must be multiple of 6")
+
+	i, err = dummyBitString().parseString(4, 13)
+	c.Check(err.Error(), gc.Equals, "index out of range")
+
+	i, err = dummyBitString().parseString(4, 12)
+	c.Check(err, gc.IsNil)
+	c.Check(i, gc.Equals, "Td")
+}
+
+// dummyBitString returns a *bitString to test on.
+func dummyBitString() *bitString {
+	return &bitString{"00000100111000110"}
+}
+
+var _ = gc.Suite(&BitStringSuite{})

--- a/parsed_consent.go
+++ b/parsed_consent.go
@@ -1,0 +1,179 @@
+package iabconsent
+
+import (
+	"encoding/base64"
+	"fmt"
+	"time"
+)
+
+const (
+	VersionBitOffset        = 0
+	VersionBitSize          = 6
+	CreatedBitOffset        = 6
+	CreatedBitSize          = 36
+	UpdatedBitOffset        = 42
+	UpdatedBitSize          = 36
+	CmpIdOffset             = 78
+	CmpIdSize               = 12
+	CmpVersionOffset        = 90
+	CmpVersionSize          = 12
+	ConsentScreenSizeOffset = 102
+	ConsentScreenSize       = 6
+	ConsentLanguageOffset   = 108
+	ConsentLanguageSize     = 12
+	VendorListVersionOffset = 120
+	VendorListVersionSize   = 12
+	PurposesOffset          = 132
+	PurposesSize            = 24
+	MaxVendorIdOffset       = 156
+	MaxVendorIdSize         = 16
+	EncodingTypeOffset      = 172
+	VendorBitfieldOffset    = 173
+	DefaultConsentOffset    = 173
+	NumEntriesOffset        = 174
+	NumEntriesSize          = 12
+	SingleOrRangeOffset     = 186
+	SingleVendorIdOffset    = 187
+	SingleVendorIdSize      = 16
+	StartVendorIdOffset     = 187
+	StartVendorIdSize       = 16
+	EndVendorIdOffset       = 203
+	EndVendorIdSize         = 16
+)
+
+type ParsedConsent struct {
+	ConsentString     string
+	Version           int
+	Created           time.Time
+	LastUpdated       time.Time
+	CmpID             int
+	CmpVersion        int
+	ConsentScreen     int
+	ConsentLanguage   string
+	VendorListVersion int
+	PurposesAllowed   map[int]interface{}
+	MaxVendorID       int
+	IsRange           bool
+	ApprovedVendorIDs map[int]interface{}
+	RangeEntry        *RangeEntry
+}
+
+type RangeEntry struct {
+	DefaultConsent bool
+	NumEntries     int
+	SingleOrRange  bool
+	SingleVendorID int
+	StartVendorID  int
+	EndVendorID    int
+}
+
+// Parse...
+func Parse(s string) (*ParsedConsent, error) {
+	var b []byte
+	var err error
+
+	b, err = base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+
+	var cs = ParseBytes(b)
+	var version, cmpID, cmpVersion, consentScreen, vendorListVersion, maxVendorID,
+		numEntries, singleVendorID, startVendorID, endVendorID int
+	var created, updated int64
+	var isRange, defaultConsent, singleOrRange bool
+	var consentLanguage string
+	var purposesAllowed = make(map[int]interface{})
+	var approvedVendorIDs = make(map[int]interface{})
+
+	version, err = cs.ParseInt(VersionBitOffset, VersionBitSize)
+	if err != nil {
+		return nil, err
+	}
+	created, err = cs.ParseInt64(CreatedBitOffset, CreatedBitSize)
+	if err != nil {
+		return nil, err
+	}
+	updated, err = cs.ParseInt64(UpdatedBitOffset, UpdatedBitSize)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println(created, updated)
+	cmpID, err = cs.ParseInt(CmpIdOffset, CmpIdSize)
+	if err != nil {
+		return nil, err
+	}
+	cmpVersion, err = cs.ParseInt(CmpVersionOffset, CmpVersionSize)
+	if err != nil {
+		return nil, err
+	}
+	consentScreen, err = cs.ParseInt(ConsentScreenSizeOffset, ConsentScreenSize)
+	if err != nil {
+		return nil, err
+	}
+	consentLanguage, err = cs.ParseString(ConsentLanguageOffset, ConsentLanguageSize)
+	if err != nil {
+		return nil, err
+	}
+	vendorListVersion, err = cs.ParseInt(VendorListVersionOffset, VendorListVersionSize)
+	if err != nil {
+		return nil, err
+	}
+	purposesAllowed = cs.ParseBitList(PurposesOffset, PurposesSize)
+	maxVendorID, err = cs.ParseInt(MaxVendorIdOffset, MaxVendorIdSize)
+	if err != nil {
+		return nil, err
+	}
+	isRange = cs.ParseBit(EncodingTypeOffset)
+
+	if isRange {
+		defaultConsent = cs.ParseBit(DefaultConsentOffset)
+		numEntries, err = cs.ParseInt(NumEntriesOffset, NumEntriesSize)
+		if err != nil {
+			return nil, err
+		}
+		singleOrRange = cs.ParseBit(SingleOrRangeOffset)
+
+		if singleOrRange {
+			singleVendorID, err = cs.ParseInt(SingleVendorIdOffset, SingleVendorIdSize)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			startVendorID, err = cs.ParseInt(StartVendorIdOffset, StartVendorIdSize)
+			if err != nil {
+				return nil, err
+			}
+			endVendorID, err = cs.ParseInt(EndVendorIdOffset, EndVendorIdSize)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		approvedVendorIDs = cs.ParseBitList(VendorBitfieldOffset, len(cs.value)-1-VendorBitfieldOffset)
+	}
+
+	return &ParsedConsent{
+		ConsentString:     cs.value,
+		Version:           version,
+		Created:           time.Unix(created/10, created%10),
+		LastUpdated:       time.Unix(updated/10, updated%10),
+		CmpID:             cmpID,
+		CmpVersion:        cmpVersion,
+		ConsentScreen:     consentScreen,
+		ConsentLanguage:   consentLanguage,
+		VendorListVersion: vendorListVersion,
+		PurposesAllowed:   purposesAllowed,
+		MaxVendorID:       maxVendorID,
+		IsRange:           isRange,
+		ApprovedVendorIDs: approvedVendorIDs,
+		RangeEntry: &RangeEntry{
+			DefaultConsent: defaultConsent,
+			NumEntries:     numEntries,
+			SingleOrRange:  singleOrRange,
+			SingleVendorID: singleVendorID,
+			StartVendorID:  startVendorID,
+			EndVendorID:    endVendorID,
+		},
+	}, nil
+}

--- a/parsed_consent_fixture.go
+++ b/parsed_consent_fixture.go
@@ -1,0 +1,202 @@
+package iabconsent
+
+import "time"
+
+type consentType int
+
+const (
+	BitField consentType = iota
+	SingleRangeWithSingleID
+	SingleRangeWithRange
+	MultipleRangesWithSingleID
+	MultipleRangesWithRange
+	MultipleRangesMixed
+)
+
+var testTime = time.Unix(1525378200,8)
+
+var consentFixtures = map[consentType]*ParsedConsent{
+	// BONMj34ONMj34ABACDENALqAAAAAplY
+	BitField: {
+		ConsentString: "0000010011100011010011001000111101111110000011100011010011001000111101111110000000000000010000000000100000110001000011010000000010111010100000000000000000000000000000001010011001010110",
+		Version: 1,
+		Created: testTime,
+		LastUpdated: testTime,
+		CmpID: 1,
+		CmpVersion: 2,
+		ConsentScreen: 3,
+		ConsentLanguage: "EN",
+		VendorListVersion: 11,
+		PurposesAllowed: map[int]interface{}{
+			1: true,
+			3: true,
+			5: true,
+		},
+		MaxVendorID: 10,
+		IsRange: false,
+		ApprovedVendorIDs: map[int]interface{}{
+			1: true,
+			2: true,
+			5: true,
+			7: true,
+			9: true,
+			10: true,
+		},
+	},
+	// BONMj34ONMj34ABACDENALqAAAAAqABAD2AAAAAAAAAAAAAAAAAAAAAAAAAA
+	SingleRangeWithSingleID: {
+		ConsentString: "000001001110001101001100100011110111111000001110001101001100100011110111111000000000000001000000000010000011000100001101000000001011101010000000000000000000000000000000101010000000000001000000000011110110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		Version: 1,
+		Created: testTime,
+		LastUpdated: testTime,
+		CmpID: 1,
+		CmpVersion: 2,
+		ConsentScreen: 3,
+		ConsentLanguage: "EN",
+		VendorListVersion: 11,
+		PurposesAllowed: map[int]interface{}{
+			1: true,
+			3: true,
+			5: true,
+		},
+		MaxVendorID: 10,
+		IsRange: true,
+		ApprovedVendorIDs: map[int]interface{}{},
+		DefaultConsent: false,
+		NumEntries: 1,
+		RangeEntries: []*RangeEntry{
+			{
+				SingleOrRange: false,
+				SingleVendorID: 123,
+			},
+		},
+	},
+	// BONMj34ONMj34ABACDENALqAAAAAqABgD2AdQAAAAAAAAAAAAAAAAAAAAAAAAAA
+	SingleRangeWithRange: {
+		ConsentString: "0000010011100011010011001000111101111110000011100011010011001000111101111110000000000000010000000000100000110001000011010000000010111010100000000000000000000000000000001010100000000000011000000000111101100000000111010100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		Version: 1,
+		Created: testTime,
+		LastUpdated: testTime,
+		CmpID: 1,
+		CmpVersion: 2,
+		ConsentScreen: 3,
+		ConsentLanguage: "EN",
+		VendorListVersion: 11,
+		PurposesAllowed: map[int]interface{}{
+			1: true,
+			3: true,
+			5: true,
+		},
+		MaxVendorID: 10,
+		IsRange: true,
+		ApprovedVendorIDs: map[int]interface{}{},
+		DefaultConsent: false,
+		NumEntries: 1,
+		RangeEntries: []*RangeEntry{
+			{
+				SingleOrRange: true,
+				StartVendorID: 123,
+				EndVendorID: 234,
+			},
+		},
+	},
+	// BONMj34ONMj34ABACDENALqAAAAAqACAD2AOoAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+	MultipleRangesWithSingleID: {
+		ConsentString: "00000100111000110100110010001111011111100000111000110100110010001111011111100000000000000100000000001000001100010000110100000000101110101000000000000000000000000000000010101000000000001000000000001111011000000000111010100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		Version: 1,
+		Created: testTime,
+		LastUpdated: testTime,
+		CmpID: 1,
+		CmpVersion: 2,
+		ConsentScreen: 3,
+		ConsentLanguage: "EN",
+		VendorListVersion: 11,
+		PurposesAllowed: map[int]interface{}{
+			1: true,
+			3: true,
+			5: true,
+		},
+		MaxVendorID: 10,
+		IsRange: true,
+		ApprovedVendorIDs: map[int]interface{}{},
+		DefaultConsent: false,
+		NumEntries: 2,
+		RangeEntries: []*RangeEntry{
+			{
+				SingleOrRange: false,
+				SingleVendorID: 123,
+			},
+			{
+				SingleOrRange: false,
+				SingleVendorID: 234,
+			},
+		},
+	},
+	// BONMj34ONMj34ABACDENALqAAAAAqACgD2AdUBWQHIAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+	MultipleRangesWithRange: {
+		ConsentString: "0000010011100011010011001000111101111110000011100011010011001000111101111110000000000000010000000000100000110001000011010000000010111010100000000000000000000000000000001010100000000000101000000000111101100000000111010101000000010101100100000001110010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		Version: 1,
+		Created: testTime,
+		LastUpdated: testTime,
+		CmpID: 1,
+		CmpVersion: 2,
+		ConsentScreen: 3,
+		ConsentLanguage: "EN",
+		VendorListVersion: 11,
+		PurposesAllowed: map[int]interface{}{
+			1: true,
+			3: true,
+			5: true,
+		},
+		MaxVendorID: 10,
+		IsRange: true,
+		ApprovedVendorIDs: map[int]interface{}{},
+		DefaultConsent: false,
+		NumEntries: 2,
+		RangeEntries: []*RangeEntry{
+			{
+				SingleOrRange: true,
+				StartVendorID: 123,
+				EndVendorID: 234,
+			},
+			{
+				SingleOrRange: true,
+				StartVendorID: 345,
+				EndVendorID: 456,
+			},
+		},
+	},
+	// BONMj34ONMj34ABACDENALqAAAAAqACAD3AVkByAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+	MultipleRangesMixed: {
+		ConsentString: "000001001110001101001100100011110111111000001110001101001100100011110111111000000000000001000000000010000011000100001101000000001011101010000000000000000000000000000000101010000000000010000000000011110111000000010101100100000001110010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		Version: 1,
+		Created: testTime,
+		LastUpdated: testTime,
+		CmpID: 1,
+		CmpVersion: 2,
+		ConsentScreen: 3,
+		ConsentLanguage: "EN",
+		VendorListVersion: 11,
+		PurposesAllowed: map[int]interface{}{
+			1: true,
+			3: true,
+			5: true,
+		},
+		MaxVendorID: 10,
+		IsRange: true,
+		ApprovedVendorIDs: map[int]interface{}{},
+		DefaultConsent: false,
+		NumEntries: 2,
+		RangeEntries: []*RangeEntry{
+			{
+				SingleOrRange: false,
+				SingleVendorID: 123,
+			},
+			{
+				SingleOrRange: true,
+				StartVendorID: 345,
+				EndVendorID: 456,
+			},
+		},
+	},
+}

--- a/parsed_consent_test.go
+++ b/parsed_consent_test.go
@@ -1,0 +1,32 @@
+package iabconsent
+
+import (
+	gc "github.com/go-check/check"
+)
+
+type ParsedConsentSuite struct{}
+
+func (p *ParsedConsentSuite) TestErrorCases(c *gc.C) {
+	var cases = []struct {
+		EncodedString string
+		Error         string
+	}{
+		{
+			EncodedString: "BONJ5bvONJ5bvAMAPyFRAL7AAAAMhuqKklS-gAAAAAAAAAAAAAAAAAAAAAAAAAAzzz",
+			Error:         "FTP",
+		},
+	}
+
+	for _, tc := range cases {
+		c.Log(tc.EncodedString)
+		_, err := Parse(tc.EncodedString)
+		c.Check(err, gc.Equals, tc.Error)
+		c.Assert(err, gc.Equals, tc.Error)
+	}
+}
+
+func (p *ParsedConsentSuite) TestFail(c *gc.C) {
+	c.Assert(true, gc.IsNil)
+}
+
+var _ = gc.Suite(&ParsedConsentSuite{})

--- a/parsed_consent_test.go
+++ b/parsed_consent_test.go
@@ -1,6 +1,8 @@
 package iabconsent
 
 import (
+	"sort"
+
 	gc "github.com/go-check/check"
 )
 
@@ -12,21 +14,76 @@ func (p *ParsedConsentSuite) TestErrorCases(c *gc.C) {
 		Error         string
 	}{
 		{
-			EncodedString: "BONJ5bvONJ5bvAMAPyFRAL7AAAAMhuqKklS-gAAAAAAAAAAAAAAAAAAAAAAAAAAzzz",
-			Error:         "FTP",
+			EncodedString: "//BONJ5bvONJ5bvAMAPyFRAL7AAAAMhuqKklS-gAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			Error:         "illegal base64 data at input byte 0",
+		},
+		{
+			// base64.RawURLEncoding.EncodeToString([]byte("10011010110110101"))
+			EncodedString: "MTAwMTEwMTAxMTAxMTAxMDE",
+			Error:         "index out of range",
 		},
 	}
 
 	for _, tc := range cases {
 		c.Log(tc.EncodedString)
 		_, err := Parse(tc.EncodedString)
-		c.Check(err, gc.Equals, tc.Error)
-		c.Assert(err, gc.Equals, tc.Error)
+		c.Check(err.Error(), gc.Equals, tc.Error)
 	}
 }
 
-func (p *ParsedConsentSuite) TestFail(c *gc.C) {
-	c.Assert(true, gc.IsNil)
+func (p *ParsedConsentSuite) TestParseConsentStrings(c *gc.C) {
+	var cases = []struct {
+		Type consentType
+		EncodedString string
+	}{
+		{
+			Type:         BitField,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAplY",
+		},
+		{
+			Type:         SingleRangeWithSingleID,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqABAD2AAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+		{
+			Type:         SingleRangeWithRange,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqABgD2AdQAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+		{
+			Type:         MultipleRangesWithSingleID,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqACAD2AOoAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+		{
+			Type:         MultipleRangesWithRange,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqACgD2AdUBWQHIAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+		{
+			Type:         MultipleRangesMixed,
+			EncodedString: "BONMj34ONMj34ABACDENALqAAAAAqACAD3AVkByAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		},
+	}
+
+	for _, tc := range cases {
+		c.Log(tc)
+		pc, err := Parse(tc.EncodedString)
+		c.Check(err, gc.IsNil)
+
+		normalizeParsedConsent(pc)
+		normalizeParsedConsent(consentFixtures[tc.Type])
+
+		c.Assert(pc, gc.DeepEquals, consentFixtures[tc.Type])
+	}
+}
+
+func normalizeParsedConsent(p *ParsedConsent) {
+	sort.Slice(p.RangeEntries, func(i, j int) bool {
+		return p.RangeEntries[i].SingleOrRange
+	})
+	sort.Slice(p.RangeEntries, func(i, j int) bool {
+		return p.RangeEntries[i].SingleVendorID < p.RangeEntries[j].SingleVendorID
+	})
+	sort.Slice(p.RangeEntries, func(i, j int) bool {
+		return p.RangeEntries[i].StartVendorID < p.RangeEntries[j].StartVendorID
+	})
 }
 
 var _ = gc.Suite(&ParsedConsentSuite{})

--- a/test_register_test.go
+++ b/test_register_test.go
@@ -1,0 +1,9 @@
+package iabconsent
+
+import (
+	"testing"
+
+	gc "github.com/go-check/check"
+)
+
+func Test(t *testing.T) { gc.TestingT(t) }


### PR DESCRIPTION
I created a Go implementation of a Consent String Parser according to the [IAB Consent String 1.1 Spec](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/Consent%20string%20and%20vendor%20list%20formats%20v1.1%20Final.md)